### PR TITLE
Improve accessibility with skip link and titles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,9 @@ function App() {
   return (
     <>
       <Router>
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
         <Header />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/assets/data/socials.json
+++ b/src/assets/data/socials.json
@@ -1,26 +1,32 @@
 [
   {
     "icon": "FaSoundcloud",
-    "link": "https://on.soundcloud.com/t7HhfKA18YEEcNCL8"
+    "link": "https://on.soundcloud.com/t7HhfKA18YEEcNCL8",
+    "name": "SoundCloud"
   },
   {
     "icon": "FaSpotify",
-    "link": "https://open.spotify.com/artist/7xjHn8ys29MbBk4tYQRRJx"
+    "link": "https://open.spotify.com/artist/7xjHn8ys29MbBk4tYQRRJx",
+    "name": "Spotify"
   },
   {
     "icon": "FaYoutube",
-    "link": "https://youtube.com/@WedgeFundMusic?si=qmezRGkesmVusyDE&sub_confirmation=1"
+    "link": "https://youtube.com/@WedgeFundMusic?si=qmezRGkesmVusyDE&sub_confirmation=1",
+    "name": "YouTube"
   },
   {
     "icon": "FaInstagram",
-    "link": "https://www.instagram.com/wedgymusic/"
+    "link": "https://www.instagram.com/wedgymusic/",
+    "name": "Instagram"
   },
   {
     "icon": "FaApple",
-    "link": "https://www.canva.com/design/DAGFfVE-Yec/w7gcJdYKT2ql0XYfHapifA/view?utm_content=DAGFfVE-Yec&utm_campaign=designshare&utm_medium=link&utm_source=editor"
+    "link": "https://www.canva.com/design/DAGFfVE-Yec/w7gcJdYKT2ql0XYfHapifA/view?utm_content=DAGFfVE-Yec&utm_campaign=designshare&utm_medium=link&utm_source=editor",
+    "name": "Apple Music"
   },
   {
     "icon": "FaTiktok",
-    "link": "https://www.tiktok.com"
+    "link": "https://www.tiktok.com",
+    "name": "TikTok"
   }
 ]

--- a/src/components/BandcampPlayer/BandcampPlayer.tsx
+++ b/src/components/BandcampPlayer/BandcampPlayer.tsx
@@ -7,8 +7,10 @@ interface SongProps {
 export default function BandcampPlayer({ song }: { song: SongProps }) {
   return (
     <iframe
-      style={{ border: 0, width: "350px", height: "442px" }} // Use an object here
+      style={{ border: 0, width: "350px", height: "442px" }}
       src={song.src}
+      title={song.title}
+      loading="lazy"
       seamless
     >
       <a href={song.href}>{song.title}</a>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -19,19 +19,29 @@ export default function Header() {
       </a>
 
       {/* Desktop */}
-      <div className="hidden md:flex space-x-4 text-white group justify-center md:justify-end md:ml-auto">
-        {socials.map(({ icon, link }, index) => {
+      <div
+        className="hidden md:flex space-x-4 text-white group justify-center md:justify-end md:ml-auto"
+        aria-label="Social media links"
+      >
+        {socials.map(({ icon, link, name }, index) => {
           const IconComponent = icons[icon as IconKey];
-          return <Icon key={index} icon={IconComponent} link={link} />;
+          return (
+            <Icon key={index} icon={IconComponent} link={link} name={name} />
+          );
         })}
       </div>
 
       {/* Mobile */}
       {isHomePage && (
-        <div className="fixed bottom-12 left-0 right-0 flex md:hidden justify-center space-x-4 text-white group">
-          {socials.map(({ icon, link }, index) => {
+        <div
+          className="fixed bottom-12 left-0 right-0 flex md:hidden justify-center space-x-4 text-white group"
+          aria-label="Social media links"
+        >
+          {socials.map(({ icon, link, name }, index) => {
             const IconComponent = icons[icon as IconKey];
-            return <Icon key={index} icon={IconComponent} link={link} />;
+            return (
+              <Icon key={index} icon={IconComponent} link={link} name={name} />
+            );
           })}
         </div>
       )}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,7 +15,7 @@ export default function Header() {
         href="/"
         className="text-white text-5xl font-kalnia hover:text-gray-300 text-center md:text-left mb-4 md:mb-0"
       >
-        <h1>Wedgy.</h1>
+        <span>Wedgy.</span>
       </a>
 
       {/* Desktop */}

--- a/src/components/Header/Icon.tsx
+++ b/src/components/Header/Icon.tsx
@@ -1,13 +1,16 @@
 interface IconProps {
-    icon: React.ElementType;
-    link: string;
-  }
-  
-  export default function Icon({ icon: IconComponent, link }: IconProps) {
-    return (
-      <a href={link} target="_blank" rel="noopener noreferrer">
-        <IconComponent className="group-hover:blur-sm hover:!blur-none transition duration-200 hover:text-gray-300 text-4xl md:text-2xl" />
-      </a>
-    );
+  icon: React.ElementType;
+  link: string;
+  name: string;
 }
-  
+
+export default function Icon({ icon: IconComponent, link, name }: IconProps) {
+  return (
+    <a href={link} aria-label={name} target="_blank" rel="noopener noreferrer">
+      <IconComponent
+        className="group-hover:blur-sm hover:!blur-none transition duration-200 hover:text-gray-300 text-4xl md:text-2xl"
+        aria-hidden="true"
+      />
+    </a>
+  );
+}

--- a/src/components/Header/Navbar/Navbar.tsx
+++ b/src/components/Header/Navbar/Navbar.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 
 export default function MobileNav() {
   const [isOpen, setIsOpen] = useState(false);
+  const location = useLocation();
 
   const menuLinks = [
     { linkAddress: "/", linkText: "HOME" },
@@ -13,7 +15,7 @@ export default function MobileNav() {
   ];
 
   return (
-    <nav>
+    <nav aria-label="Main">
       <button
         onClick={() => setIsOpen(true)}
         className="md:hidden z-40 fixed top-4 right-4 text-white focus:outline-none"
@@ -66,6 +68,11 @@ export default function MobileNav() {
                     href={link.linkAddress}
                     onClick={() => setIsOpen(false)}
                     className="hover:text-gray-400 cursor-pointer"
+                    aria-current={
+                      location.pathname === link.linkAddress
+                        ? "page"
+                        : undefined
+                    }
                   >
                     {link.linkText}
                   </a>

--- a/src/components/HomeMenu/HomeMenu.tsx
+++ b/src/components/HomeMenu/HomeMenu.tsx
@@ -1,4 +1,7 @@
+import { useLocation } from "react-router-dom";
+
 export default function HomeMenu() {
+  const location = useLocation();
   const menuLinks = [
     { linkAddress: "/tour", linkText: "TOUR" },
     { linkAddress: "/about", linkText: "ABOUT" },
@@ -8,7 +11,7 @@ export default function HomeMenu() {
   ];
 
   return (
-    <nav>
+    <nav aria-label="Home">
       <ul className="z-30 text-white font-lexend flex flex-col text-5xl md:text-xl gap-[8vh] md:flex-row space-x-4 list-none absolute top-1/2 left-1/2 w-10/12 justify-between items-center text-center transform -translate-x-1/2 -translate-y-1/2 group">
         {menuLinks.map((link, index) => (
           <li
@@ -18,6 +21,9 @@ export default function HomeMenu() {
             <a
               href={link.linkAddress}
               className="relative cursor-pointer decoration-2 tracking-widest hover:drop-shadow-lg transition duration-200 before:content-[''] before:absolute before:inset-0 before:border before:border-white before:scale-x-0 before:origin-left before:transition-transform before:duration-300 hover:before:scale-x-100"
+              aria-current={
+                location.pathname === link.linkAddress ? "page" : undefined
+              }
             >
               {link.linkText}
             </a>

--- a/src/components/TourDates/TourDate.tsx
+++ b/src/components/TourDates/TourDate.tsx
@@ -18,16 +18,17 @@ export default function TourDate({ tourDate, pastOrFuture }: TourDateProps) {
         <li className="mt-7">
           {pastOrFuture === "upcoming events" ? (
             <a
-              className="bg-white text-black text-center p-3 hover:bg-gray-300 "
+              className="bg-white text-black text-center p-3 hover:bg-gray-300"
               target="_blank"
+              rel="noopener noreferrer"
               href={tourDate.ticket_link}
             >
               Buy Tickets
             </a>
           ) : (
-            <a className="bg-gray-800 text-gray-400 text-center p-3 cursor-not-allowed ">
+            <span className="bg-gray-800 text-gray-400 text-center p-3">
               Unavailable
-            </a>
+            </span>
           )}
         </li>
       </ul>

--- a/src/components/TourDates/TourDatesContainer.tsx
+++ b/src/components/TourDates/TourDatesContainer.tsx
@@ -14,7 +14,7 @@ export default function TourDatesContainer({
   return (
     <>
       <div className="mb-24">
-        <h3 className="text-3xl text-center pb-10">{title}</h3>
+        <h2 className="text-3xl text-center pb-10">{title}</h2>
         <div className="flex flex-wrap">
           {tourDates.map((tourDate) => {
             return <TourDate tourDate={tourDate} pastOrFuture={title} />;

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,7 @@ body {
 .responsive-text {
   font-size: clamp(0.875rem, 2vw + 1rem, 1.25rem);
 }
+
+.skip-link {
+  @apply absolute left-2 top-2 -translate-y-full bg-black text-white px-4 py-2 focus:translate-y-0 focus:outline-none;
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -7,16 +7,16 @@ export default function About() {
   }, []);
   return (
     <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
-      <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
+      <h1 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         about
-      </h2>
-      <h3 className="text-center text-xl md:text-3xl mt-10">
+      </h1>
+      <h2 className="text-center text-xl md:text-3xl mt-10">
         Wedgy are an Alt-Rock band, based in Leeds.
-      </h3>
+      </h2>
       <img
         className="w-11/12 m-auto mt-10 md:max-w-3xl"
         src={aboutImg}
-        alt="Members of Wedgy posing together"
+        alt="Wedgy performing outdoors"
       />
       <div className="flex flex-col gap-7 mt-10 max-w-sm sm:max-w-md md:max-w-3xl lg:max-w-5xl  m-auto mb-10 md:text-xl md:leading-">
         <p>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,8 +1,12 @@
+import { useEffect } from "react";
 import aboutImg from "../assets/images/about-img.jpg";
 
 export default function About() {
+  useEffect(() => {
+    document.title = "About | Wedgy";
+  }, []);
   return (
-    <main className="min-h-[calc(100vh-9.25rem)]">
+    <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
       <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         about
       </h2>
@@ -12,7 +16,7 @@ export default function About() {
       <img
         className="w-11/12 m-auto mt-10 md:max-w-3xl"
         src={aboutImg}
-        alt=""
+        alt="Members of Wedgy posing together"
       />
       <div className="flex flex-col gap-7 mt-10 max-w-sm sm:max-w-md md:max-w-3xl lg:max-w-5xl  m-auto mb-10 md:text-xl md:leading-">
         <p>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,9 +6,9 @@ export default function Contact() {
   }, []);
   return (
     <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
-      <h2 className="font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
+      <h1 className="font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         CONTACT
-      </h2>
+      </h1>
       <p className="text-center mt-24 mb-24">wedgefundmusic@gmail.com</p>
     </main>
   );

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,11 @@
+import { useEffect } from "react";
+
 export default function Contact() {
+  useEffect(() => {
+    document.title = "Contact | Wedgy";
+  }, []);
   return (
-    <main className="min-h-[calc(100vh-9.25rem)]">
+    <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
       <h2 className="font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         CONTACT
       </h2>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,17 @@
 import backgroundImg from "../assets/images/background.jpg";
 import HomeMenu from "../components/HomeMenu/HomeMenu";
 
+import { useEffect } from "react";
+
 export default function Home() {
+  useEffect(() => {
+    document.title = "Home | Wedgy";
+  }, []);
   return (
-    <main className="overflow-hidden w-full min-h-[calc(100vh-9.25rem)] z-10">
+    <main
+      id="main-content"
+      className="overflow-hidden w-full min-h-[calc(100vh-9.25rem)] z-10"
+    >
       <img
         className="-z-10 absolute inset-0 object-cover w-full h-full object-right"
         src={backgroundImg}

--- a/src/pages/Merch.tsx
+++ b/src/pages/Merch.tsx
@@ -1,6 +1,14 @@
+import { useEffect } from "react";
+
 export default function Merch() {
+  useEffect(() => {
+    document.title = "Merch | Wedgy";
+  }, []);
   return (
-    <div className="w-full text-center text-3xl flex gap-1 flex-col min-h-[calc(100vh-9.25rem)]">
+    <main
+      id="main-content"
+      className="w-full text-center text-3xl flex gap-1 flex-col min-h-[calc(100vh-9.25rem)]"
+    >
       <h2>coming soon</h2>
       <h2>coming soon</h2>
       <h2>coming soon</h2>
@@ -15,6 +23,6 @@ export default function Merch() {
       <h2>coming soon</h2>
       <h2>coming soon</h2>
       <h2>coming soon</h2>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Merch.tsx
+++ b/src/pages/Merch.tsx
@@ -9,7 +9,7 @@ export default function Merch() {
       id="main-content"
       className="w-full text-center text-3xl flex gap-1 flex-col min-h-[calc(100vh-9.25rem)]"
     >
-      <h2>coming soon</h2>
+      <h1>coming soon</h1>
       <h2>coming soon</h2>
       <h2>coming soon</h2>
       <h2>coming soon</h2>

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -8,12 +8,12 @@ export default function Music() {
   }, []);
   return (
     <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
-      <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
+      <h1 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         MUSIC
-      </h2>
-      <h3 className="m-auto font-lexend text-white text-4xl text-center tracking-widest mt-10 mb-10">
+      </h1>
+      <h2 className="m-auto font-lexend text-white text-4xl text-center tracking-widest mt-10 mb-10">
         SINGLES
-      </h3>
+      </h2>
       <div className="flex justify-center flex-wrap gap-24 w-11/12 m-auto mb-16">
         {bandCampData.map((song) => {
           if (song.type === "single") {
@@ -21,9 +21,9 @@ export default function Music() {
           }
         })}
       </div>
-      <h3 className="m-auto font-lexend text-white text-4xl text-center tracking-widest mt-10 mb-10">
+      <h2 className="m-auto font-lexend text-white text-4xl text-center tracking-widest mt-10 mb-10">
         BUY THE ALBUM
-      </h3>
+      </h2>
       <div className="flex justify-center flex-wrap gap-24 w-11/12 m-auto mb-16">
         {bandCampData.map((song) => {
           if (song.type === "album") {

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -1,9 +1,13 @@
+import { useEffect } from "react";
 import BandcampPlayer from "../components/BandcampPlayer/BandcampPlayer";
 import bandCampData from "../assets/data/bandcamp.json";
 
 export default function Music() {
+  useEffect(() => {
+    document.title = "Music | Wedgy";
+  }, []);
   return (
-    <main className="min-h-[calc(100vh-9.25rem)]">
+    <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
       <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         MUSIC
       </h2>

--- a/src/pages/Tour.tsx
+++ b/src/pages/Tour.tsx
@@ -5,6 +5,10 @@ import TourDatesContainer from "../components/TourDates/TourDatesContainer";
 import { TourDateType } from "../utils/types/types";
 
 export default function Tour() {
+  useEffect(() => {
+    document.title = "Tour | Wedgy";
+  }, []);
+
   const [data, setData] = useState<TourDateType[]>([]); // Use the type here
   const [futureDates, setFutureDates] = useState<TourDateType[]>([]); // Use the type here
   const [pastDates, setPastDates] = useState<TourDateType[]>([]); // Use the type here
@@ -66,7 +70,7 @@ export default function Tour() {
   }, [data]);
 
   return (
-    <main className="min-h-[calc(100vh-9.25rem)]">
+    <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
       <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         TOUR
       </h2>

--- a/src/pages/Tour.tsx
+++ b/src/pages/Tour.tsx
@@ -71,9 +71,9 @@ export default function Tour() {
 
   return (
     <main id="main-content" className="min-h-[calc(100vh-9.25rem)]">
-      <h2 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
+      <h1 className=" font-lexend text-white text-5xl md:text-7xl text-center tracking-widest">
         TOUR
-      </h2>
+      </h1>
       <div className=" m-auto w-11/12 mt-10">
         <TourDatesContainer tourDates={futureDates} title={"upcoming events"} />
         <TourDatesContainer tourDates={pastDates} title={"past events"} />


### PR DESCRIPTION
## Summary
- add skip link to navigate directly to main content
- implement dynamic page titles for each route
- add `main-content` landmarks across pages
- update alt text for about page image

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854805ab614832a80700c74902f8a2d